### PR TITLE
Install locally provided build requirements separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ The following fields are required:
 
 The following fields are optional:
 
+* `options` (list of strings) specify project options. Currently, the
+  following options can be set:
+  * `allow-vendor-change` Allow to change vendor while installing packages
+    from project RPMS directory
+
 * `buildoptions` (string) additional options to pass to `sfdk
   build`. For example, `-j4`.
 

--- a/tbuilder
+++ b/tbuilder
@@ -150,18 +150,7 @@ class Commands:
         s, e = run_with_check(cmd)
         print(s)
 
-    def system_has(self, tool):
-        if self.use_sfdk:
-            # prepare sfdk to run
-            run_with_check("sfdk config target=" + tool)
-            run_with_check("sfdk config snapshot=%s" % self.project)
-            cmd = "sfdk build-shell zypper -x search --provides --match-exact".split()
-        else:
-            cmd = "sb2 -t %s zypper -x search --provides --match-exact" % self.target_snapshot(tool)
-            cmd = cmd.split()
-        return cmd
-
-    def can_install(self, tool, rpmfname):
+    def can_install_cmd(self, tool, rpmfname):
         fname = os.path.abspath(rpmfname)
         dname = os.path.dirname(fname)
         if self.use_sfdk:
@@ -332,7 +321,7 @@ class RPM:
             return True
         print('Checking whether %s can be used:' % self.short_rpmfname, end=" ", flush=True)
         self.missing = []
-        cmd = commands.can_install(self.tool, self.rpmfname)
+        cmd = commands.can_install_cmd(self.tool, self.rpmfname)
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         s = proc.stdout.decode('utf-8')
         root = ET.fromstring(s)
@@ -552,7 +541,8 @@ class SystemProvided:
             return False
 
     def _system_has(self, r):
-        cmd = commands.system_has(self.tool)
+        cmd = commands.run_cmd(self.tool,
+                               'zypper -x search --provides --match-exact').split()
         cmd.append(r)
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # zypper returns non-zero if failing to find

--- a/tbuilder
+++ b/tbuilder
@@ -92,8 +92,7 @@ class Commands:
         cmd += os.path.abspath(rpmpath)
         run_with_check(cmd)
 
-    def install_package(self, tool, package, force=False, extra_repo=None):
-        print('Installing', package, flush=True, end=": ")
+    def install_package_cmd(self, tool, package, force=False, extra_repo=None):
         if self.use_sfdk:
             cmd = "sfdk tools exec %s " % self.target_snapshot(tool)
         else:
@@ -105,6 +104,11 @@ class Commands:
         if force:
             cmd += "--force-resolution "
         cmd += "-y --allow-vendor-change --allow-unsigned-rpm " + package
+        return cmd
+
+    def install_package(self, tool, package, force=False, extra_repo=None):
+        print('Installing', package, flush=True, end=": ")
+        cmd = self.install_package_cmd(tool=tool, package=package, force=force, extra_repo=extra_repo)
         proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         with open( os.path.join(logdir(tool),
                                 "zypper-install-" + package + ".log"), "w" ) as f:
@@ -120,20 +124,20 @@ class Commands:
         if self.use_sfdk:
             make += '\t' + 'sfdk config no-fix-version\n'
             make += '\t' + 'sfdk config target=' + tool + '\n'
-            make += '\t' + 'sfdk config output-dir=' + rpmpath + '\n'
+            #make += '\t' + 'sfdk config output-dir=' + rpmpath + '\n'
             make += '\t' + 'sfdk config snapshot=%s \n' % self.project
             make += '\t' + '(cd %s && ' % bdir
             make += 'sfdk config specfile=' + specpath + ' && '
             make += 'sfdk build -d %s %s %s)\n' % (buildoptions, srcpath, rpmbuild)
         else:
+            # make += '\t' + \
+            #     '(cd {bdir} && mb2 -t {target} -o {output} -s {spec} --snapshot={snap} build -d {bopts} {src} {rpmbuild})\n'.format(
+            #         bdir = bdir, target = tool, output = rpmpath, spec = specpath,
+            #         snap = self.project, bopts = buildoptions, src = srcpath, rpmbuild = rpmbuild)
             make += '\t' + \
-                '(cd {bdir} && mb2 -t {target} -o {output} -s {spec} --snapshot={snap} build -d {bopts} {src} {rpmbuild})\n'.format(
+                '(cd {bdir} && mb2 -t {target} -s {spec} --snapshot={snap} build -d {bopts} {src} {rpmbuild})\n'.format(
                     bdir = bdir, target = tool, output = rpmpath, spec = specpath,
                     snap = self.project, bopts = buildoptions, src = srcpath, rpmbuild = rpmbuild)
-
-        # update success flag
-        make += '\t@echo %s > %s\n' % (os.path.basename(specpath), current_build_successful_flag(tool))
-        make += '\t@echo %s\n' % success_txt_for_error
         return make
 
     def refresh_system(self, tool):
@@ -485,14 +489,21 @@ class Spec:
                                                                                         release=release,
                                                                                         spec=specpath)
 
+        make += '\t' + commands.install_package_cmd(tool = tool,
+                                                    force=True, extra_repo=rpmpath,
+                                                    package = " ".join(req)) + '\n'
         make += commands.make_section(bdir = bdir, tool = tool, rpmpath = rpmpath, specpath = specpath,
                                       buildoptions = buildoptions,
                                       srcpath = srcpath, rpmbuild = rpmbuild)
+        make += '\t(cd {bdir} && mv RPMS/*.rpm {rpmpath})\n'.format(bdir=bdir, rpmpath = rpmpath)
 
         # finalize
         make += '\ttouch ' + target_spec(self.specfname, tool) + '\n'
         if release is not None:
             make += '\t@echo {release} > {relfile}\n'.format(release=release, relfile=relfile)
+        # update success flag
+        make += '\t@echo %s > %s\n' % (os.path.basename(specpath), current_build_successful_flag(tool))
+        make += '\t@echo %s\n' % success_txt_for_error
         make += '\texit 1\n'
         make += '\n'
         return make

--- a/tbuilder
+++ b/tbuilder
@@ -489,9 +489,10 @@ class Spec:
                                                                                         release=release,
                                                                                         spec=specpath)
 
-        make += '\t' + commands.install_package_cmd(tool = tool,
-                                                    force=True, extra_repo=rpmpath,
-                                                    package = " ".join(req)) + '\n'
+        if len(req) > 0:
+            make += '\t' + commands.install_package_cmd(tool = tool,
+                                                        force=True, extra_repo=rpmpath,
+                                                        package = " ".join(['"%s"' % r for r in req])) + '\n'
         make += commands.make_section(bdir = bdir, tool = tool, rpmpath = rpmpath, specpath = specpath,
                                       buildoptions = buildoptions,
                                       srcpath = srcpath, rpmbuild = rpmbuild)

--- a/tbuilder
+++ b/tbuilder
@@ -54,6 +54,7 @@ def run_with_check(cmd, check_error=True, cwd = None):
 class Commands:
     def __init__(self):
         self.project = ""
+        self.allow_vendor_change = False
         # check whether to use sfdk or not
         if shutil.which("mb2") is not None and shutil.which("sb2") is not None:
             self.use_sfdk = False
@@ -62,9 +63,6 @@ class Commands:
         else:
             print('Cannot find sfdk nor sb2/mb2')
             sys.exit(-1)
-
-    def set_project(self, project):
-        self.project = project
 
     def target_base(self, tool):
         return tool
@@ -103,7 +101,9 @@ class Commands:
         cmd += "in "
         if force:
             cmd += "--force-resolution "
-        cmd += "-y --allow-vendor-change --allow-unsigned-rpm " + package
+        cmd += "-y --allow-unsigned-rpm "
+        if self.allow_vendor_change: cmd += '--allow-vendor-change '
+        cmd += package
         return cmd
 
     def install_package(self, tool, package, force=False, extra_repo=None):
@@ -158,7 +158,9 @@ class Commands:
         else:
             cmd = ["sb2", "-t", self.target_snapshot(tool), "-R"]
         cmd.extend(["zypper", "-x", "-p", dname])
-        cmd.extend( ("in --dry-run --download-only -y --allow-vendor-change --allow-unsigned-rpm").split() )
+        cmd.extend( ("in --dry-run --download-only -y --allow-unsigned-rpm").split() )
+        if self.allow_vendor_change:
+            cmd.append('--allow-vendor-change')
         cmd.append(fname)
         return cmd
 
@@ -611,6 +613,7 @@ project_name = config.get('project', '')
 targets = config.get('targets', [])
 rpmrootdir = config.get('rpms', '')
 macros = config.get('macros', [])
+project_options = config.get('options', [])
 buildoptions = config.get('buildoptions', '')
 shadow_builds = config.get('shadow_builds', [])
 install_extra_packages = config.get('install', [])
@@ -631,7 +634,11 @@ if len(rpmrootdir) < 1:
     print('No RPMS directory specified in the project config.yaml')
     sys.exit(-1)
 
-commands.set_project(project_name)
+# check specified options
+if 'allow-vendor-change' in project_options:
+    commands.allow_vendor_change = True
+
+commands.project = project_name
 
 # main loop
 summary = {}

--- a/tbuilder
+++ b/tbuilder
@@ -124,6 +124,7 @@ class Commands:
         if self.use_sfdk:
             make += '\t' + 'sfdk config no-fix-version\n'
             make += '\t' + 'sfdk config target=' + tool + '\n'
+            make += '\t' + 'sfdk config --drop output-dir\n'
             #make += '\t' + 'sfdk config output-dir=' + rpmpath + '\n'
             make += '\t' + 'sfdk config snapshot=%s \n' % self.project
             make += '\t' + '(cd %s && ' % bdir


### PR DESCRIPTION
As described in 

- https://forum.sailfishos.org/t/mb2-allow-to-install-dependencies-with-vendor-change/6057
- https://forum.sailfishos.org/t/mb2-shared-output-directory-allow-to-disable-zypper-distribution-update/6066

there are cases which require dropping `zypper dup` and allow to change vendor while installing new packages. 

This handling is implemented here by 

- installing build requirements via separate command before calling SDK build engine
- building without using shared output directory
- moving ready RPMs into the shared directory